### PR TITLE
Fixes for links that use MD5

### DIFF
--- a/python/generator.py
+++ b/python/generator.py
@@ -23,6 +23,9 @@ class Generator:
 			
 	def validate(self):
 		
+		#Checks if there is a query string, dumps it and changes hostname
+		if(self.link.find('?') + 1):
+			self.link = self.link[:self.link.index('?')].replace('://', '://storage.googleapis.com/linear-theater-254209.appspot.com/')
 		#Checks if the link is supported
 		if(re.search("-0{0,2}1-1080p", self.link)):
 			self.loop()

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -52,6 +52,14 @@ function validateInput() {
 	if(!/^((https?)|(ftp):\/\/)\S*(-0{0,2}1-1080p)\S*\.\S+/.test(document.getElementById('link').value) || /\s/g.test(document.getElementById('link').value))
 		setMessage('link', 'Oh rats, I cannot use this URL. Please have a look at the documentation.');
 	
+	else if(document.getElementById('link').value.indexOf('?') + 1) {
+		link = document.getElementById('link').value;
+		link = link.substring(0, link.indexOf('?'));
+		link = link.replace('://', '://storage.googleapis.com/linear-theater-254209.appspot.com/');
+		document.getElementById('link').value = link;
+		setMessage(false, 'The link you bring is of a format completely new, so I changed it for you.');
+	}
+	
 	else if(start < 1)
 		setMessage('startEp', 'So far there has been none, who start their episodes with a number less than one!');
 	


### PR DESCRIPTION
Besides replacing the link's hostname as discussed in the group, also made it so the query strings are dropped from the resultant query